### PR TITLE
[FIX] remove outdated dependency argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
     ],
     install_requires=[
         'appdirs',
-        'argparse',
         'click',
         'configparser',  # for python2 compat
         # We need to pin docutils version, see


### PR DESCRIPTION
This was only needed for Python 3.4 and lower.

@moduon MT-83